### PR TITLE
add groovydoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,13 @@
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
                     <version>1.5</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-groovydoc</artifactId>
+                            <version>${groovy.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Release perform failed with:
```
[INFO] [ERROR] Repository "comtwosigmaznai-1000" failures
[INFO] [ERROR]   Rule "javadoc-staging" failures
[INFO] [ERROR]     * Missing: no javadoc jar found in folder '/com/twosigma/znai/znai-groovy/0.14'
[INFO] [ERROR]     * Missing: no javadoc jar found in folder '/com/twosigma/znai/znai-testing-tcli/0.14'
```

The change in this PR is the only relevant difference with webtau that I can see.  Unfortunately, I can't see any obvious way to test this without attempting a release 😞 