### PR TITLE
add list all overloads for a specified java method name

### DIFF
--- a/znai-docs/documentation/snippets/HelloWorld.java
+++ b/znai-docs/documentation/snippets/HelloWorld.java
@@ -35,4 +35,8 @@ class HelloWorld {
     public void importantAction() {
         // TODO important
     }
+
+    public Data createData() {
+        // create data
+    }
 }

--- a/znai-docs/documentation/snippets/java.md
+++ b/znai-docs/documentation/snippets/java.md
@@ -64,19 +64,27 @@ Use `bodyOnly` to only display body of your type.
 
 To display multiple methods at once use `entries` parameter to pass a list of method names.
     
-    :include-java: HelloWorld.java {entries: ["sampleMethod", "importantAction"]}
+    :include-java: HelloWorld.java {entries: ["createData", "importantAction"]}
 
 This will render:
 
-:include-java: HelloWorld.java {entries: ["sampleMethod", "importantAction"]}
+:include-java: HelloWorld.java {entries: ["createData", "importantAction"]}
 
 List important methods signatures at one place by passing `signatureOnly: true`.
 
-    :include-java: HelloWorld.java {entries: ["sampleMethod", "importantAction"], signatureOnly: true}
+    :include-java: HelloWorld.java {entries: ["createData", "importantAction"], signatureOnly: true}
 
 This will render: 
 
-:include-java: HelloWorld.java {entries: ["sampleMethod", "importantAction"], signatureOnly: true}
+:include-java: HelloWorld.java {entries: ["createData", "importantAction"], signatureOnly: true}
+
+# Multiple Overloads
+
+To list of the overloads of a method, specify method name using `entries` param.
+
+    :include-java: HelloWorld.java {entries: "sampleMethod", signatureOnly: true}
+
+:include-java: HelloWorld.java {entries: "sampleMethod", signatureOnly: true}
 
 # Class JavaDoc
 

--- a/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePluginBase.java
+++ b/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePluginBase.java
@@ -49,9 +49,9 @@ abstract public class JavaIncludePluginBase implements IncludePlugin {
         this.pluginParams = pluginParams;
         fullPath = componentsRegistry.resourceResolver().fullPath(pluginParams.getFreeParam());
         entry = pluginParams.getOpts().get("entry");
-        entries = pluginParams.getOpts().get("entries");
+        entries = pluginParams.getOpts().getList("entries");
 
-        if (entry != null && entries != null) {
+        if (entry != null && !entries.isEmpty()) {
             throw new IllegalArgumentException("specify either entry or entries");
         }
 

--- a/znai-java/src/main/java/com/twosigma/znai/java/parser/JavaCode.java
+++ b/znai-java/src/main/java/com/twosigma/znai/java/parser/JavaCode.java
@@ -58,6 +58,10 @@ public class JavaCode {
         return codeVisitor.findMethodDetails(methodNameWithOptionalTypes);
     }
 
+    public List<JavaMethod> findAllMethods(String methodNameWithOptionalTypes) {
+        return codeVisitor.findAllMethodDetails(methodNameWithOptionalTypes);
+    }
+
     public JavaField fieldByName(String fieldName) {
         return codeVisitor.findFieldDetails(fieldName);
     }

--- a/znai-java/src/test/groovy/com/twosigma/znai/java/extensions/JavaIncludePluginTest.groovy
+++ b/znai-java/src/test/groovy/com/twosigma/znai/java/extensions/JavaIncludePluginTest.groovy
@@ -25,9 +25,9 @@ import static com.twosigma.webtau.Ddjt.throwException
 class JavaIncludePluginTest {
     @Test
     void "includes multiple entries of java method signatures"() {
-        def result = process("Simple.java", "{entries: ['methodA', 'methodB'], signatureOnly: true}")
+        def result = process("Simple.java", "{entries: ['methodA', 'createData'], signatureOnly: true}")
         result.should == "void methodA()\n" +
-                "void methodB(String p)"
+                "Data createData()"
     }
 
     @Test
@@ -48,11 +48,29 @@ class JavaIncludePluginTest {
     }
 
     @Test
+    void "extract multiple signatures of a method overloads"() {
+        def result = process("Simple.java", "{entries: 'methodB', signatureOnly: true}")
+        result.should == 'void methodB(String p)\n' +
+                'void methodB(String p, Boolean b)'
+    }
+
+    @Test
+    void "extract multiple full bodies of a method overloads"() {
+        def result = process("Simple.java", "{entries: 'methodB'}")
+        result.should == 'void methodB(String p) {\n' +
+                '    doB();\n' +
+                '}\n' +
+                '\n' +
+                'void methodB(String p, Boolean b) {\n' +
+                '    doBPlus();\n' +
+                '}'
+    }
+
+    @Test
     void "optionally removes return in body only mode"() {
         process("Simple.java", "{entry: 'createData', bodyOnly: true, removeReturn: true}").should ==
                 "construction(a, b,\n" +
                 "             c, d);"
-
     }
 
     @Test

--- a/znai-java/src/test/resources/Simple.java
+++ b/znai-java/src/test/resources/Simple.java
@@ -4,11 +4,11 @@ class Simple {
     }
 
     void methodB(String p) {
-
+        doB();
     }
 
     void methodB(String p, Boolean b) {
-
+        doBPlus();
     }
 
     Data createData() {


### PR DESCRIPTION
Add option to list of all the method overloads to help with reference documentation.

```
:include-java: HelloWorld.java {entries: "sampleMethod", signatureOnly: true}
```

```
class HelloWorld {
    private int numberOfStudents;

    public String sampleMethod(String p1, int p2) {
     //...
    }

    public void sampleMethod(Map<String, Integer> p1, int p2, boolean isActive) {
        // overloaded method
    }

    public void importantAction() {
        // TODO important
    }

    public Data createData() {
        // create data
    }
}
```
```
public String sampleMethod(String p1, int p2)
public void sampleMethod(Map<String, Integer> p1, int p2, boolean isActive)
```