### PR TITLE
extensible markup configurations

### DIFF
--- a/znai-cli/src/main/java/com/twosigma/znai/cli/ZnaiCliApp.java
+++ b/znai-cli/src/main/java/com/twosigma/znai/cli/ZnaiCliApp.java
@@ -16,15 +16,15 @@
 
 package com.twosigma.znai.cli;
 
+import com.twosigma.znai.cli.extension.CliCommandConfig;
 import com.twosigma.znai.console.ConsoleOutputs;
 import com.twosigma.znai.console.ansi.AnsiConsoleOutput;
 import com.twosigma.znai.console.ansi.Color;
-import com.twosigma.znai.utils.FileUtils;
-import com.twosigma.znai.cli.extension.CliCommandConfig;
 import com.twosigma.znai.html.HtmlPage;
 import com.twosigma.znai.html.reactjs.ReactJsBundle;
 import com.twosigma.znai.server.DocumentationServer;
 import com.twosigma.znai.server.preview.DocumentationPreview;
+import com.twosigma.znai.utils.FileUtils;
 import com.twosigma.znai.web.WebResource;
 import com.twosigma.znai.website.ProgressReporter;
 import com.twosigma.znai.website.WebSite;
@@ -147,7 +147,7 @@ public class ZnaiCliApp {
         WebSite.Configuration webSiteCfg = WebSite.withRoot(config.getSourceRoot()).
                 withReactJsBundle(reactJsBundle).
                 withId(getDocId()).
-                withMarkupType(config.getMarkupType()).
+                withDocumentationType(config.getMarkupType()).
                 withMetaFromJsonFile(config.getSourceRoot().resolve("meta.json")).
                 withFileWithLookupPaths("lookup-paths").
                 withFooterPath(config.getSourceRoot().resolve("footer.md")).

--- a/znai/src/main/java/com/twosigma/znai/website/WebSite.java
+++ b/znai/src/main/java/com/twosigma/znai/website/WebSite.java
@@ -32,9 +32,8 @@ import com.twosigma.znai.utils.FileUtils;
 import com.twosigma.znai.utils.JsonUtils;
 import com.twosigma.znai.web.WebResource;
 import com.twosigma.znai.web.extensions.WebSiteResourcesProviders;
-import com.twosigma.znai.website.markups.MarkdownParsingConfiguration;
 import com.twosigma.znai.website.markups.MarkupParsingConfiguration;
-import com.twosigma.znai.website.markups.SphinxParsingConfiguration;
+import com.twosigma.znai.website.markups.MarkupParsingConfigurations;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -45,7 +44,6 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static com.twosigma.znai.parser.MarkupTypes.MARKDOWN;
-import static com.twosigma.znai.parser.MarkupTypes.SPHINX;
 import static com.twosigma.znai.utils.FileUtils.fileTextContent;
 import static com.twosigma.znai.website.ProgressReporter.reportPhase;
 import static java.util.stream.Collectors.toList;
@@ -97,7 +95,7 @@ public class WebSite {
         globalAssetsJavaScript = WebResource.withPath("assets.js");
         searchIndexJavaScript = WebResource.withPath(SEARCH_INDEX_FILE_NAME);
         auxiliaryFilesRegistry = new AuxiliaryFilesRegistry();
-        markupParsingConfiguration = createMarkupParsingConfiguration();
+        markupParsingConfiguration = MarkupParsingConfigurations.byName(cfg.documentationType);
         globalSearchEntries = new GlobalSearchEntries();
         localSearchEntries = new LocalSearchEntries();
         auxiliaryFilesLastUpdateTime = new HashMap<>();
@@ -226,15 +224,6 @@ public class WebSite {
     public void redeployAuxiliaryFileIfRequired(Path path) {
         if (auxiliaryFilesRegistry.requiresDeployment(path)) {
             deployAuxiliaryFile(auxiliaryFilesRegistry.auxiliaryFileByPath(path));
-        }
-    }
-
-    private MarkupParsingConfiguration createMarkupParsingConfiguration() {
-        switch (cfg.markupType) {
-            case SPHINX:
-                return new SphinxParsingConfiguration();
-            default:
-                return new MarkdownParsingConfiguration();
         }
     }
 
@@ -541,7 +530,7 @@ public class WebSite {
         private String logoRelativePath;
         private List<WebResource> registeredExtraJavaScripts;
         private boolean isPreviewEnabled;
-        private String markupType = MARKDOWN;
+        private String documentationType = MARKDOWN;
         private DocMeta docMeta = new DocMeta(Collections.emptyMap());
         private ReactJsBundle reactJsBundle;
 
@@ -550,8 +539,8 @@ public class WebSite {
             registeredExtraJavaScripts = new ArrayList<>();
         }
 
-        public Configuration withMarkupType(String markupType) {
-            this.markupType = markupType;
+        public Configuration withDocumentationType(String markupType) {
+            this.documentationType = markupType;
             return this;
         }
 

--- a/znai/src/main/java/com/twosigma/znai/website/WebSite.java
+++ b/znai/src/main/java/com/twosigma/znai/website/WebSite.java
@@ -179,11 +179,9 @@ public class WebSite {
             return toc.getIndex();
         }
 
-        return toc.getTocItems().stream().filter(ti ->
-                path.toAbsolutePath().getParent().getFileName().toString().equals(ti.getDirName()) &&
-                        path.getFileName().toString().equals(
-                                ti.getFileNameWithoutExtension() + "." + markupParsingConfiguration.filesExtension()))
-                .findFirst().orElse(null);
+        return toc.getTocItems().stream().filter(tocItem -> path.toAbsolutePath().equals(markupPath(tocItem)))
+                .findFirst()
+                .orElse(null);
     }
 
     public HtmlPageAndPageProps regeneratePage(TocItem tocItem) {

--- a/znai/src/main/java/com/twosigma/znai/website/markups/MarkdownParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/MarkdownParsingConfiguration.java
@@ -17,8 +17,9 @@
 package com.twosigma.znai.website.markups;
 
 import com.twosigma.znai.core.ComponentsRegistry;
-import com.twosigma.znai.parser.commonmark.MarkdownParser;
 import com.twosigma.znai.parser.MarkupParser;
+import com.twosigma.znai.parser.MarkupTypes;
+import com.twosigma.znai.parser.commonmark.MarkdownParser;
 import com.twosigma.znai.structure.PlainTextTocGenerator;
 import com.twosigma.znai.structure.PlainTextTocPatcher;
 import com.twosigma.znai.structure.TableOfContents;
@@ -29,6 +30,11 @@ import java.nio.file.Path;
 
 public class MarkdownParsingConfiguration implements MarkupParsingConfiguration {
     public static final String TOC_PATCH_NAME = "toc-patch";
+
+    @Override
+    public String configurationName() {
+        return MarkupTypes.MARKDOWN;
+    }
 
     @Override
     public TableOfContents createToc(ComponentsRegistry componentsRegistry) {

--- a/znai/src/main/java/com/twosigma/znai/website/markups/MarkdownParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/MarkdownParsingConfiguration.java
@@ -56,14 +56,13 @@ public class MarkdownParsingConfiguration implements MarkupParsingConfiguration 
     }
 
     @Override
-    public String filesExtension() {
-        return "md";
-    }
-
-    @Override
     public Path fullPath(ComponentsRegistry componentsRegistry, Path root, TocItem tocItem) {
         return componentsRegistry.resourceResolver().fullPath(tocItem.getDirName()
                  + (tocItem.getDirName().isEmpty() ? "" : File.separator) +
                 (tocItem.getFileNameWithoutExtension() + "." + filesExtension()));
+    }
+
+    private String filesExtension() {
+        return "md";
     }
 }

--- a/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfiguration.java
@@ -24,6 +24,8 @@ import com.twosigma.znai.structure.TocItem;
 import java.nio.file.Path;
 
 public interface MarkupParsingConfiguration {
+    String configurationName();
+
     TableOfContents createToc(ComponentsRegistry componentsRegistry);
 
     MarkupParser createMarkupParser(ComponentsRegistry componentsRegistry);

--- a/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfiguration.java
@@ -30,7 +30,5 @@ public interface MarkupParsingConfiguration {
 
     MarkupParser createMarkupParser(ComponentsRegistry componentsRegistry);
 
-    String filesExtension();
-
     Path fullPath(ComponentsRegistry componentsRegistry, Path root, TocItem tocItem);
 }

--- a/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfigurations.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/MarkupParsingConfigurations.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.znai.website.markups;
+
+import com.twosigma.znai.utils.ServiceLoaderUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MarkupParsingConfigurations {
+    private static Set<MarkupParsingConfiguration> configurations =
+            ServiceLoaderUtils.load(MarkupParsingConfiguration.class);
+
+    private MarkupParsingConfigurations() {
+    }
+
+    public static MarkupParsingConfiguration byName(String name) {
+        List<MarkupParsingConfiguration> configurations = MarkupParsingConfigurations.configurations.stream()
+                .filter(c -> name.equals(c.configurationName()))
+                .collect(Collectors.toList());
+
+        if (configurations.isEmpty()) {
+            throw new RuntimeException("can't find markup configuration for" +
+                    " <" + name + ">. Available configurations: \n" + renderAvailable());
+        }
+
+        if (configurations.size() > 1) {
+            throw new RuntimeException("more than one configuration found for <" + name + ">:\n" + renderAvailable());
+        }
+
+        return configurations.get(0);
+    }
+
+    private static String renderAvailable() {
+        return configurations.stream()
+                .map(c -> c.configurationName() + "(" + c.getClass() + ")")
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/znai/src/main/java/com/twosigma/znai/website/markups/SphinxParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/SphinxParsingConfiguration.java
@@ -18,6 +18,7 @@ package com.twosigma.znai.website.markups;
 
 import com.twosigma.znai.core.ComponentsRegistry;
 import com.twosigma.znai.parser.MarkupParser;
+import com.twosigma.znai.parser.MarkupTypes;
 import com.twosigma.znai.parser.sphinx.DocTreeTocGenerator;
 import com.twosigma.znai.parser.sphinx.SphinxDocTreeParser;
 import com.twosigma.znai.structure.TableOfContents;
@@ -26,6 +27,11 @@ import com.twosigma.znai.structure.TocItem;
 import java.nio.file.Path;
 
 public class SphinxParsingConfiguration implements MarkupParsingConfiguration {
+    @Override
+    public String configurationName() {
+        return MarkupTypes.SPHINX;
+    }
+
     @Override
     public TableOfContents createToc(ComponentsRegistry componentsRegistry) {
         return new DocTreeTocGenerator(filesExtension()).generate(

--- a/znai/src/main/java/com/twosigma/znai/website/markups/SphinxParsingConfiguration.java
+++ b/znai/src/main/java/com/twosigma/znai/website/markups/SphinxParsingConfiguration.java
@@ -44,12 +44,11 @@ public class SphinxParsingConfiguration implements MarkupParsingConfiguration {
     }
 
     @Override
-    public String filesExtension() {
-        return "xml";
-    }
-
-    @Override
     public Path fullPath(ComponentsRegistry componentsRegistry, Path root, TocItem tocItem) {
         return root.resolve(tocItem.getDirName()).resolve(tocItem.getFileNameWithoutExtension() + "." + filesExtension());
+    }
+
+    private String filesExtension() {
+        return "xml";
     }
 }

--- a/znai/src/main/resources/META-INF/services/com.twosigma.znai.website.markups.MarkupParsingConfiguration
+++ b/znai/src/main/resources/META-INF/services/com.twosigma.znai.website.markups.MarkupParsingConfiguration
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.twosigma.znai.website.markups.MarkdownParsingConfiguration
+com.twosigma.znai.website.markups.SphinxParsingConfiguration

--- a/znai/src/test/groovy/com/twosigma/znai/website/markups/MarkupParsingConfigurationsTest.groovy
+++ b/znai/src/test/groovy/com/twosigma/znai/website/markups/MarkupParsingConfigurationsTest.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.znai.website.markups
+
+import com.twosigma.znai.parser.MarkupTypes
+import org.junit.Test
+
+import static com.twosigma.webtau.Ddjt.code
+import static com.twosigma.webtau.Ddjt.throwException
+
+class MarkupParsingConfigurationsTest {
+    @Test
+    void "finds registered configuration by name"() {
+        def markdownConfig = MarkupParsingConfigurations.byName(MarkupTypes.MARKDOWN)
+        assert markdownConfig instanceof MarkdownParsingConfiguration
+
+        def sphinxConfig = MarkupParsingConfigurations.byName(MarkupTypes.SPHINX)
+        assert sphinxConfig instanceof SphinxParsingConfiguration
+    }
+
+    @Test
+    void "lists available configurations when wrong name is specified"() {
+        code {
+            MarkupParsingConfigurations.byName('unknown')
+        } should throwException("can't find markup configuration for <unknown>. Available configurations: \n" +
+                "markdown(class com.twosigma.znai.website.markups.MarkdownParsingConfiguration)\n" +
+                "sphinx(class com.twosigma.znai.website.markups.SphinxParsingConfiguration)")
+    }
+}


### PR DESCRIPTION
This change will allow to register additional implementations of `MarkupParsingConfiguration`. It can be used to either support different types of markup languages (i.e. ascii doctor) or provide a different Table Of Contents generation. 