### PR TITLE
Upgrade ant-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-compress</artifactId>
-                <version>1.4</version>
+                <version>1.5</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
1.4 has an issue whereby the artifact name in the published pom does not match the artifactId in Maven Central.  This causes issues for Gradle and SBT users as both of those tools fail resolution upon encountering such issues.  1.5 fixes this.