### PR TITLE
Handle 'Cannot read propety content of undefined' during search. Thou…

### DIFF
--- a/znai-reactjs/src/doc-elements/search/Search.js
+++ b/znai-reactjs/src/doc-elements/search/Search.js
@@ -54,7 +54,7 @@ class Search {
             const sections = p.content.filter((de) => {
                 return tocItem.dirName === sectionCoords.dirName &&
                     tocItem.fileName === sectionCoords.fileName &&
-                    de.type === 'Section' && de.id === sectionCoords.pageSectionId})
+                    de.type === 'Section' && (!sectionCoords.pageSectionId || de.id === sectionCoords.pageSectionId)})
 
             sections.forEach((s) => matching.push(s))
         })


### PR DESCRIPTION
…gh indexId expects to be dirname@@filename@@pagesectionId, sometimes pagesectionId is black like design-pattern@@enum-singleton@@