### PR TITLE
upgrade jackson from 2.9.9 to 2.10, so databind can be the same version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,10 +118,24 @@
         <vertx.io.version>3.5.4</vertx.io.version>
         <commonmark.version>0.9.0</commonmark.version>
         <antlr.version>4.5</antlr.version>
-        <jackson.verson>2.9.9</jackson.verson>
-        <jackson.databind.verson>2.9.9.2</jackson.databind.verson>
+        <jackson.verson>2.9.10</jackson.verson>
         <webtau.version>1.13</webtau.version>
         <jaxb.version>2.3.0</jaxb.version>
+        <ant.version>1.10.5</ant.version>
+        <ant-compress.version>1.5</ant-compress.version>
+        <jsoup.version>1.10.2</jsoup.version>
+        <commons-io.version>2.6</commons-io.version>
+        <freemarker.version>2.3.23</freemarker.version>
+        <commons-cli.version>1.4</commons-cli.version>
+        <commons-csv.version>1.4</commons-csv.version>
+        <commons-compress.version>1.14</commons-compress.version>
+        <commons-lang3.version>3.5</commons-lang3.version>
+        <plantuml.version>1.2017.16</plantuml.version>
+        <json-path.version>2.4.0</json-path.version>
+        <slf4j-simple.version>1.7.25</slf4j-simple.version>
+        <junit.version>4.12</junit.version>
+        <javaparser-core.version>3.0.1</javaparser-core.version>
+        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
     </properties>
 
     <dependencyManagement>
@@ -147,55 +161,61 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>${commons-io.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.23</version>
+                <version>${freemarker.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.3.1</version>
+                <version>${commons-cli.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
-                <version>1.4</version>
+                <version>${commons-csv.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.5</version>
+                <version>${commons-lang3.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>net.sourceforge.plantuml</groupId>
                 <artifactId>plantuml</artifactId>
-                <version>1.2017.16</version>
+                <version>${plantuml.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
-                <version>2.4.0</version>
+                <version>${json-path.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.0</version>
+                <version>${ant.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-compress</artifactId>
-                <version>1.5</version>
+                <version>${ant-compress.version}</version>
             </dependency>
 
             <dependency>
@@ -213,19 +233,19 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.25</version>
+                <version>${slf4j-simple.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>${junit.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
             </dependency>
 
             <dependency>
@@ -255,13 +275,13 @@
             <dependency>
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
-                <version>3.0.1</version>
+                <version>${javaparser-core.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.10.2</version>
+                <version>${jsoup.version}</version>
             </dependency>
 
             <dependency>
@@ -279,7 +299,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.databind.verson}</version>
+                <version>${jackson.verson}</version>
             </dependency>
 
             <dependency>

--- a/znai-core/pom.xml
+++ b/znai-core/pom.xml
@@ -58,8 +58,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-core-groovy</artifactId>
-            <version>${webtau.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/znai-diagrams/pom.xml
+++ b/znai-diagrams/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>com.twosigma.webtau</groupId>
             <artifactId>webtau-core-groovy</artifactId>
-            <version>${webtau.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The change also replaced from jaxb-api to jakarta.xml.bind-api, since J2EE packages are not included as part of JDK in JDK11.