### PR TITLE
make all of fields in csv String. 

### DIFF
--- a/znai-reactjs/src/doc-elements/table/Table.js
+++ b/znai-reactjs/src/doc-elements/table/Table.js
@@ -52,7 +52,9 @@ const Table = ({table, ...props}) => {
                 <tr>
                     {showHeader ? table.columns.map((c, idx) => {
                         const align = c.align ? c.align : 'left'
-                        const style = {textAlign: align}
+                        const width = c.width ? c.width : 'auto'
+
+                        const style = {textAlign: align, width: width}
                         return (<th key={idx} style={style}>{c.title}</th>)
                     }) : null}
                 </tr>

--- a/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
@@ -58,7 +58,7 @@ public class ApiParametersCsvParser {
         MarkupParserResult markupParserResult = markupParser.parse(path, row.get(2));
         List<Map<String, Object>> description = markupParserResult.getDocElement().contentToListOfMaps();
 
-        if (name.contains(".")) {
+        if (name.contains(".") && !name.contains("..")) {
             addNested(name, type, description);
         } else {
             apiParameters.add(name, type, description);

--- a/znai/src/main/java/com/twosigma/znai/extensions/table/CsvParser.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/table/CsvParser.java
@@ -24,8 +24,10 @@ import org.apache.commons.csv.CSVRecord;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.math.BigDecimal;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public class CsvParser {
     private CsvParser() {
@@ -63,7 +65,7 @@ public class CsvParser {
 
             for (CSVRecord record : csvRecords) {
                 Row row = new Row();
-                record.forEach(v -> row.add(convert(v)));
+                record.forEach(row::add);
 
                 if (record.size() != headerToUse.size()) {
                     throw new RuntimeException("record mismatches header. header: " + headerToUse +
@@ -77,11 +79,5 @@ public class CsvParser {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static Object convert(Object v) {
-        String s = v.toString();
-        Scanner scanner = new Scanner(s);
-        return scanner.hasNextBigDecimal() ? new BigDecimal(s) : s;
     }
 }


### PR DESCRIPTION
1. We don't have to convert a number to BigDecimal unless znai needs to compute the field. Also ApiParametersCsvParser throws an exception if a field is a number.
For example, when we define a return value, a number can't be an argument.
```api-parameters
0,, on success
```
ApiParametersCsvParser.parseRow(ApiParametersCsvParser.java:55) throws an exception since it tries to cast BigDecimal to String.

2. Another bug fix is that if name has more than one dot, it's not a nested part. We need to handle a name with multiple dots as is.
For example, 
```api-parameters
...,, Variable parameters
```

3. add missing width for a table