### PR TITLE
Override elements through theme registry. expose DocumentationLayout.

### DIFF
--- a/znai-reactjs/src/doc-elements/DefaultElementsLibrary.js
+++ b/znai-reactjs/src/doc-elements/DefaultElementsLibrary.js
@@ -53,7 +53,6 @@ import Image from './images/Image'
 import {CliCommand, presentationCliCommandHandler} from './cli/CliCommand'
 import {CliOutput, presentationCliOutput} from './cli/CliOutput'
 import EmbeddedAnnotatedImage from './images/EmbeddedAnnotatedImage'
-import Footer from './structure/Footer'
 import presentationAnnotatedImageHandler from './images/PresentationAnnotatedImage'
 import presentationGraphVizHandler from './graphviz/PresentationGraphVizFlow'
 import {MarkdownAndResult, presentationMarkdownAndResultHandler} from './markdown/MarkdownAndResult'
@@ -68,7 +67,8 @@ import JsxGroup from './jsx/JsxGroup'
 
 import DiagramLegend from './diagrams/DiagramLegend'
 
-import {pageTypesRegistry} from "./page/PageTypesRegistry"
+import DocumentationLayout from './DocumentationLayout'
+import Footer from './structure/Footer'
 
 const library = {}
 const presentationElementHandlers = {}
@@ -176,14 +176,15 @@ library.ApiParameters = wrappedInContentBlock(ApiParameters)
 
 library.JupyterCell = JupyterCell
 
-library.Footer = Footer
-
 library.WebTauRest = WebTauRest
 
 library.OpenApiOperation = OpenApiOperation
 library.DiagramLegend = DiagramLegend
 
 registerDocUtilsElements(library)
+
+library.DocumentationLayout = DocumentationLayout
+library.Footer = Footer
 
 /**
  * to make a DocElement aligned with a page content it needs to have a content-block assigned.
@@ -201,7 +202,5 @@ themeRegistry.registerAsBase(new Theme({
     presentationElementHandlers: presentationElementHandlers}))
 
 themeRegistry.register(znaiDarkTheme)
-
-library.pageTypesRegistry = pageTypesRegistry
 
 export {library as elementsLibrary, presentationElementHandlers}

--- a/znai-reactjs/src/doc-elements/Documentation.js
+++ b/znai-reactjs/src/doc-elements/Documentation.js
@@ -38,7 +38,6 @@ import PresentationRegistry from './presentation/PresentationRegistry'
 import AllPagesAtOnce from './AllPagesAtOnce'
 
 import {setDocMeta} from './docMeta'
-import DocumentationLayout from './DocumentationLayout'
 
 import pageContentProcessor from './pageContentProcessor.js'
 
@@ -172,6 +171,8 @@ export class Documentation extends Component {
                                                           onTocUpdate={this.onTocUpdate}
                                                           onDocMetaUpdate={this.onDocMetaUpdate}
                                                           onError={this.onPageGenError}/> : null
+
+        const DocumentationLayout = elementsLibrary.DocumentationLayout
 
         return (
             <WithTheme>{() =>

--- a/znai-reactjs/src/index.js
+++ b/znai-reactjs/src/index.js
@@ -27,16 +27,17 @@ require('./doc-elements/search/Search.css')
 const {Documentation} = require('./doc-elements/Documentation')
 const {DocumentationPreparationScreen} = require('./screens/documentation-preparation/DocumentationPreparationScreen')
 const {Landing} = require('./screens/landing/Landing')
-const {elementsLibrary} = require('./doc-elements/DefaultElementsLibrary')
 const {themeRegistry} = require('./theme/ThemeRegistry')
+const {pageTypesRegistry} = require('./doc-elements/page/PageTypesRegistry')
+
 const lunr = require('lunr')
 
 global.React = React
 global.Documentation = Documentation
 global.DocumentationPreparationScreen = DocumentationPreparationScreen
 global.Landing = Landing
-global.elementsLibrary = elementsLibrary
 global.themeRegistry = themeRegistry
+global.pageTypesRegistry = pageTypesRegistry
 global.lunr = lunr
 
 if (process.env.NODE_ENV !== "production") {

--- a/znai-reactjs/src/theme/ThemeRegistry.js
+++ b/znai-reactjs/src/theme/ThemeRegistry.js
@@ -35,6 +35,12 @@ class ThemeRegistry {
         return this._selectedTheme
     }
 
+    overrideElement(elementId, newElement) {
+        this.themes.forEach(theme => {
+            theme.elementsLibrary[elementId] = newElement
+        })
+    }
+
     register(theme) {
         const found = this.themes.filter(t => t.name === theme.name)
         if (found.length > 0) {


### PR DESCRIPTION
Introduce a better way to override a component to render parts of documentation across multiple themes. 