### PR TITLE
Expose TableOfContents through DocStructure interface for plugins to access

### DIFF
--- a/znai-core/src/main/java/com/twosigma/znai/parser/MarkupParser.java
+++ b/znai-core/src/main/java/com/twosigma/znai/parser/MarkupParser.java
@@ -17,6 +17,7 @@
 package com.twosigma.znai.parser;
 
 import com.twosigma.znai.parser.docelement.DocElement;
+import com.twosigma.znai.structure.PageMeta;
 
 import java.nio.file.Path;
 
@@ -33,4 +34,11 @@ public interface MarkupParser {
      * @see MarkupPathsResolution
      */
     MarkupParserResult parse(Path path, String markup);
+
+    /**
+     * parses only page meta
+     * @param markup markup to parse
+     * @return page meta
+     */
+    PageMeta parsePageMetaOnly(String markup);
 }

--- a/znai-core/src/main/java/com/twosigma/znai/structure/DocStructure.java
+++ b/znai-core/src/main/java/com/twosigma/znai/structure/DocStructure.java
@@ -26,4 +26,6 @@ public interface DocStructure {
     void registerGlobalAnchor(Path sourcePath, String anchorId);
     void registerLocalAnchor(Path path, String anchorId);
     String globalAnchorUrl(Path clientPath, String anchorId);
+
+    TableOfContents tableOfContents();
 }

--- a/znai-core/src/test/groovy/com/twosigma/znai/parser/TestDocStructure.groovy
+++ b/znai-core/src/test/groovy/com/twosigma/znai/parser/TestDocStructure.groovy
@@ -18,11 +18,13 @@ package com.twosigma.znai.parser
 
 import com.twosigma.znai.structure.DocStructure
 import com.twosigma.znai.structure.DocUrl
+import com.twosigma.znai.structure.TableOfContents
 
 import java.nio.file.Path
 
 class TestDocStructure implements DocStructure {
     private Set<String> validLinks = [] as Set
+    private TableOfContents toc = new TableOfContents()
 
     @Override
     void validateUrl(Path path, String sectionWithLinkTitle, DocUrl docUrl) {
@@ -65,6 +67,15 @@ class TestDocStructure implements DocStructure {
     @Override
     String globalAnchorUrl(Path clientPath, String anchorId) {
         return null
+    }
+
+    void setToc(TableOfContents testToc) {
+        this.toc = testToc
+    }
+
+    @Override
+    TableOfContents tableOfContents() {
+        return toc
     }
 
     void clearValidLinks() {

--- a/znai-core/src/test/groovy/com/twosigma/znai/parser/TestMarkdownParser.groovy
+++ b/znai-core/src/test/groovy/com/twosigma/znai/parser/TestMarkdownParser.groovy
@@ -42,6 +42,11 @@ class TestMarkdownParser extends MarkdownParser {
     }
 
     @Override
+    PageMeta parsePageMetaOnly(String markup) {
+        return new PageMeta()
+    }
+
+    @Override
     void parse(Path path, String markdown, ParserHandler handler) {
         handler.onCustomNode('TestMarkdown', [markdown: markdown])
     }

--- a/znai-core/src/test/groovy/com/twosigma/znai/parser/TestMarkupParser.groovy
+++ b/znai-core/src/test/groovy/com/twosigma/znai/parser/TestMarkupParser.groovy
@@ -34,4 +34,9 @@ class TestMarkupParser implements MarkupParser {
 
         return new MarkupParserResult(page, [], [searchEntry], [], new PageMeta())
     }
+
+    @Override
+    PageMeta parsePageMetaOnly(String markup) {
+        return new PageMeta()
+    }
 }

--- a/znai-sphinx/src/main/java/com/twosigma/znai/parser/sphinx/SphinxDocTreeParser.java
+++ b/znai-sphinx/src/main/java/com/twosigma/znai/parser/sphinx/SphinxDocTreeParser.java
@@ -50,4 +50,9 @@ public class SphinxDocTreeParser implements MarkupParser {
                 elementCreationHandler.getAuxiliaryFiles(),
                 new PageMeta());
     }
+
+    @Override
+    public PageMeta parsePageMetaOnly(String markup) {
+        return new PageMeta();
+    }
 }

--- a/znai/src/main/java/com/twosigma/znai/website/WebSiteDocStructure.java
+++ b/znai/src/main/java/com/twosigma/znai/website/WebSiteDocStructure.java
@@ -130,6 +130,11 @@ class WebSiteDocStructure implements DocStructure {
         return createUrl(new DocUrl(tocItem.getDirName(), tocItem.getFileNameWithoutExtension(), anchorId));
     }
 
+    @Override
+    public TableOfContents tableOfContents() {
+        return toc;
+    }
+
     private Optional<String> validateLink(LinkToValidate link) {
         String anchorId = link.docUrl.getAnchorId();
 


### PR DESCRIPTION
`TableOfContents` Items has page meta part. To make sure page meta is filled with data, we now parse page meta first for all the pages before attempting to parse each page fully. This is done some plugins that need access to `TableOfContents` have access to page meta parts of each `TocItem`.

Meta only parsing is fast since no plugins will be activated and no search information will be calculated. 