### PR TITLE
add custom html head extension

### DIFF
--- a/znai-docs/documentation/custom.html
+++ b/znai-docs/documentation/custom.html
@@ -1,17 +1,1 @@
-<!--
-  ~ Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <!--test extension added comment-->

--- a/znai-docs/documentation/extensions.json
+++ b/znai-docs/documentation/extensions.json
@@ -1,5 +1,6 @@
 {
   "cssResources": ["custom.css"],
   "jsResources": ["custom.js"],
-  "htmlResources": ["custom.html"]
+  "htmlResources": ["custom.html"],
+  "htmlHeadResources": ["tracking.html"]
 }

--- a/znai-docs/documentation/tracking.html
+++ b/znai-docs/documentation/tracking.html
@@ -1,0 +1,1 @@
+<!--test extension added comment to head-->

--- a/znai-server/src/main/java/com/twosigma/znai/server/landing/LandingUrlContentHandler.java
+++ b/znai-server/src/main/java/com/twosigma/znai/server/landing/LandingUrlContentHandler.java
@@ -21,8 +21,6 @@ import com.twosigma.znai.html.reactjs.HtmlReactJsPage;
 import com.twosigma.znai.html.reactjs.ReactJsBundle;
 import com.twosigma.znai.server.FavIcons;
 import com.twosigma.znai.server.urlhandlers.UrlContentHandler;
-import com.twosigma.znai.web.WebResource;
-import com.twosigma.znai.web.extensions.WebSiteResourcesProviders;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -58,13 +56,6 @@ public class LandingUrlContentHandler implements UrlContentHandler {
 
         HtmlPage htmlPage = htmlReactJsPage.create(landingTitle + " " + landingType,
                 "Landing", props, () -> "", FavIcons.DEFAULT_ICON_PATH);
-
-        WebSiteResourcesProviders.jsResources().forEach(htmlPage::addJavaScript);
-        WebSiteResourcesProviders.jsClientOnlyResources().forEach(htmlPage::addJavaScript);
-        WebSiteResourcesProviders.cssResources().forEach(htmlPage::addCss);
-        WebSiteResourcesProviders.htmlResources().map(WebResource::getTextContent)
-                .forEach(text -> htmlPage.addToBody(() -> text));
-
         return htmlPage.render("");
     }
 }

--- a/znai-site-extensions/src/main/java/com/twosigma/znai/web/extensions/WebSiteResourcesProvider.java
+++ b/znai-site-extensions/src/main/java/com/twosigma/znai/web/extensions/WebSiteResourcesProvider.java
@@ -28,7 +28,11 @@ public interface WebSiteResourcesProvider {
         return Stream.empty();
     }
 
-    default Stream<WebResource> htmlResources() {
+    default Stream<WebResource> htmlHeadResources() {
+        return Stream.empty();
+    }
+
+    default Stream<WebResource> htmlBodyResources() {
         return Stream.empty();
     }
 

--- a/znai-site-extensions/src/main/java/com/twosigma/znai/web/extensions/WebSiteResourcesProviders.java
+++ b/znai-site-extensions/src/main/java/com/twosigma/znai/web/extensions/WebSiteResourcesProviders.java
@@ -34,8 +34,12 @@ public class WebSiteResourcesProviders {
         return providers.stream().flatMap(WebSiteResourcesProvider::cssResources);
     }
 
-    public static Stream<WebResource> htmlResources() {
-        return providers.stream().flatMap(WebSiteResourcesProvider::htmlResources);
+    public static Stream<WebResource> htmlHeadResources() {
+        return providers.stream().flatMap(WebSiteResourcesProvider::htmlHeadResources);
+    }
+
+    public static Stream<WebResource> htmlBodyResources() {
+        return providers.stream().flatMap(WebSiteResourcesProvider::htmlBodyResources);
     }
 
     public static Stream<WebResource> jsResources() {

--- a/znai/src/main/java/com/twosigma/znai/html/HtmlPage.java
+++ b/znai/src/main/java/com/twosigma/znai/html/HtmlPage.java
@@ -33,7 +33,7 @@ public class HtmlPage {
     private List<WebResource> cssResources;
     private List<WebResource> javaScriptResources;
 
-    private List<RenderSupplier> headerSuppliers;
+    private List<RenderSupplier> headSuppliers;
     private List<RenderSupplier> bodySuppliers;
     private List<RenderSupplier> javaScriptSuppliers;
 
@@ -49,7 +49,7 @@ public class HtmlPage {
         cssResources = new ArrayList<>();
         javaScriptResources = new ArrayList<>();
 
-        headerSuppliers = new ArrayList<>();
+        headSuppliers = new ArrayList<>();
         bodySuppliers = new ArrayList<>();
         javaScriptSuppliers = new ArrayList<>();
     }
@@ -70,6 +70,10 @@ public class HtmlPage {
         javaScriptResources.add(0, webResource);
     }
 
+    public void addToHead(RenderSupplier supplier) {
+        headSuppliers.add(supplier);
+    }
+
     public void addToBody(RenderSupplier supplier) {
         bodySuppliers.add(supplier);
     }
@@ -84,7 +88,7 @@ public class HtmlPage {
                 "<head>\n" +
                 "<meta charset=\"utf-8\" /> \n" +
                 "<title>" + title + "</title>" +
-                headerSuppliers.stream().map(RenderSupplier::render).collect(joining("\n")) +
+                headSuppliers.stream().map(RenderSupplier::render).collect(joining("\n")) +
                 cssResources.stream().map(r -> r.generateCssLink(documentationId)).collect(joining("\n")) +
                 "\n</head>\n" +
                 "<link rel=\"shortcut icon\" href=" + favIconPath(documentationId) + "type=\"image/ico\"/>\n" +

--- a/znai/src/main/java/com/twosigma/znai/html/PageToHtmlPageConverter.java
+++ b/znai/src/main/java/com/twosigma/znai/html/PageToHtmlPageConverter.java
@@ -22,8 +22,6 @@ import com.twosigma.znai.structure.DocMeta;
 import com.twosigma.znai.structure.Footer;
 import com.twosigma.znai.structure.Page;
 import com.twosigma.znai.structure.TocItem;
-import com.twosigma.znai.web.WebResource;
-import com.twosigma.znai.web.extensions.WebSiteResourcesProviders;
 
 public class PageToHtmlPageConverter {
     private final DocMeta docMeta;
@@ -49,12 +47,6 @@ public class PageToHtmlPageConverter {
 
         HtmlReactJsPage reactJsPage = new HtmlReactJsPage(reactJsBundle);
         HtmlPage htmlPage = reactJsPage.create(title, "Documentation", docProps.toMap(), mainBodySupplier, "");
-
-        WebSiteResourcesProviders.jsResources().forEach(htmlPage::addJavaScript);
-        WebSiteResourcesProviders.jsClientOnlyResources().forEach(htmlPage::addJavaScript);
-        WebSiteResourcesProviders.cssResources().forEach(htmlPage::addCss);
-        WebSiteResourcesProviders.htmlResources().map(WebResource::getTextContent)
-                .forEach(text -> htmlPage.addToBody(() -> text));
 
         return new HtmlPageAndPageProps(htmlPage, pageProps);
     }

--- a/znai/src/main/java/com/twosigma/znai/html/ServerSideSimplifiedRenderer.java
+++ b/znai/src/main/java/com/twosigma/znai/html/ServerSideSimplifiedRenderer.java
@@ -30,7 +30,7 @@ public class ServerSideSimplifiedRenderer {
     static final String LOADING_INDICATOR = ResourceUtils.textContent("template/initial-page-loading.html");
 
     public static String renderToc(TableOfContents toc) {
-        return LOADING_INDICATOR + section(
+        return section(
                 toc.getTocItems().stream()
                         .map(ServerSideSimplifiedRenderer::renderTocLink)
                         .collect(Collectors.joining("\n")));

--- a/znai/src/main/java/com/twosigma/znai/html/reactjs/HtmlReactJsPage.java
+++ b/znai/src/main/java/com/twosigma/znai/html/reactjs/HtmlReactJsPage.java
@@ -19,6 +19,8 @@ package com.twosigma.znai.html.reactjs;
 import com.twosigma.znai.html.HtmlPage;
 import com.twosigma.znai.html.RenderSupplier;
 import com.twosigma.znai.utils.JsonUtils;
+import com.twosigma.znai.web.WebResource;
+import com.twosigma.znai.web.extensions.WebSiteResourcesProviders;
 
 import java.util.Map;
 
@@ -51,6 +53,14 @@ public class HtmlReactJsPage {
 
         reactJsBundle.clientJavaScripts().forEach(htmlPage::addJavaScript);
         reactJsBundle.clientCssResources().forEach(htmlPage::addCss);
+
+        WebSiteResourcesProviders.jsResources().forEach(htmlPage::addJavaScript);
+        WebSiteResourcesProviders.jsClientOnlyResources().forEach(htmlPage::addJavaScript);
+        WebSiteResourcesProviders.cssResources().forEach(htmlPage::addCss);
+        WebSiteResourcesProviders.htmlHeadResources().map(WebResource::getTextContent)
+                .forEach(text -> htmlPage.addToHead(() -> text));
+        WebSiteResourcesProviders.htmlBodyResources().map(WebResource::getTextContent)
+                .forEach(text -> htmlPage.addToBody(() -> text));
 
         return htmlPage;
     }

--- a/znai/src/main/java/com/twosigma/znai/website/WebSiteUserExtensions.java
+++ b/znai/src/main/java/com/twosigma/znai/website/WebSiteUserExtensions.java
@@ -34,7 +34,8 @@ public class WebSiteUserExtensions implements WebSiteResourcesProvider {
     private final List<WebResource> cssResources;
     private final List<WebResource> jsResources;
     private final List<WebResource> jsClientOnlyResources;
-    private final List<WebResource> htmlResources;
+    private final List<WebResource> htmlHeadResources;
+    private final List<WebResource> htmlBodyResources;
     private final List<WebResource> additionalFilesToDeploy;
 
     private final Map<String, ?> definition;
@@ -51,7 +52,8 @@ public class WebSiteUserExtensions implements WebSiteResourcesProvider {
         this.cssResources = extractWebResources("cssResources");
         this.jsResources = extractWebResources("jsResources");
         this.jsClientOnlyResources = extractWebResources("jsClientOnlyResources");
-        this.htmlResources = extractWebResources("htmlResources");
+        this.htmlBodyResources = extractWebResources("htmlResources"); // name is without "head" part for compatibility with existing extensions out there
+        this.htmlHeadResources = extractWebResources("htmlHeadResources");
         this.additionalFilesToDeploy = extractWebResources("additionalFilesToDeploy");
     }
 
@@ -72,8 +74,13 @@ public class WebSiteUserExtensions implements WebSiteResourcesProvider {
     }
 
     @Override
-    public Stream<WebResource> htmlResources() {
-        return htmlResources.stream();
+    public Stream<WebResource> htmlHeadResources() {
+        return htmlHeadResources.stream();
+    }
+
+    @Override
+    public Stream<WebResource> htmlBodyResources() {
+        return htmlBodyResources.stream();
     }
 
     @Override

--- a/znai/src/main/resources/template/initial-page-loading.html
+++ b/znai/src/main/resources/template/initial-page-loading.html
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2019 TWO SIGMA OPEN SOURCE, LLC
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <div id="znai-initial-page-loading" style="margin: -20px 0 0 -20px; padding: 0 40px 40px 0; width: 100vw; height: 100vh; display: flex; justify-content: center; align-items: center">
     <div></div>
 </div>

--- a/znai/src/test/groovy/com/twosigma/znai/html/HtmlPageTest.groovy
+++ b/znai/src/test/groovy/com/twosigma/znai/html/HtmlPageTest.groovy
@@ -1,0 +1,25 @@
+package com.twosigma.znai.html
+
+import org.junit.Test
+
+import static com.twosigma.webtau.Ddjt.contain
+
+class HtmlPageTest {
+    @Test
+    void "should add custom render to body"() {
+        def page = new HtmlPage()
+        page.addToBody { 'custom body block' }
+
+        def rendered = page.render('my-doc')
+        rendered.should contain('<body>\ncustom body block')
+    }
+
+    @Test
+    void "should add custom render to head"() {
+        def page = new HtmlPage()
+        page.addToHead { 'custom head block' }
+
+        def rendered = page.render('my-doc')
+        rendered.should contain('custom head block\n</head>')
+    }
+}

--- a/znai/src/test/groovy/com/twosigma/znai/html/ServerSideSimplifiedRendererTest.groovy
+++ b/znai/src/test/groovy/com/twosigma/znai/html/ServerSideSimplifiedRendererTest.groovy
@@ -29,7 +29,6 @@ class ServerSideSimplifiedRendererTest {
     @Test
     void "should render TOC with page sections"() {
         ServerSideSimplifiedRenderer.renderToc(toc).should ==
-                ServerSideSimplifiedRenderer.LOADING_INDICATOR +
                 '<section style="max-width: 640px; margin-left: auto; margin-right: auto;">\n' +
                 '<article>\n' +
                 '<a href="chapter-a/page-one/">Page One</a>\n' +

--- a/znai/src/test/groovy/com/twosigma/znai/website/WebSiteUserExtensionsTest.groovy
+++ b/znai/src/test/groovy/com/twosigma/znai/website/WebSiteUserExtensionsTest.groovy
@@ -33,6 +33,7 @@ class WebSiteUserExtensionsTest {
                 jsResources: ['custom.js', 'components.js'],
                 jsClientOnlyResources: ['custom-client.js'],
                 additionalFilesToDeploy: ['font1.woff2', 'font2.woff2'],
+                htmlHeadResources: ['tracking.html'],
                 htmlResources: ['custom.html']])
 
         def paths = { name -> extensions."$name"().collect(toList()).path }
@@ -40,7 +41,8 @@ class WebSiteUserExtensionsTest {
         paths('cssResources').should == ['custom.css', 'another.css']
         paths('jsResources').should == ['custom.js', 'components.js']
         paths('jsClientOnlyResources').should == ['custom-client.js']
-        paths('htmlResources').should == ['custom.html']
+        paths('htmlHeadResources').should == ['tracking.html']
+        paths('htmlBodyResources').should == ['custom.html']
         paths('additionalFilesToDeploy').should == ['font1.woff2', 'font2.woff2']
     }
 


### PR DESCRIPTION
This is mostly so tracking extension could be added before anything else loaded.

There is one place where I didn't rename `htmlResources` to `htmlBodyResources` as there are some internal clients that may be using this already.  @jyeakel it would help if we could work with them and rename it while there are no outside users of this feature yet. 