### PR TITLE
support for links inside code snippets for include-file|java|groovy

### DIFF
--- a/znai-core/pom.xml
+++ b/znai-core/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>

--- a/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
+++ b/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
@@ -59,7 +59,7 @@ public class CodeReferences {
                 Stream.of(AuxiliaryFile.builtTime(referencesPath)) : Stream.empty();
     }
 
-    public boolean referencesProvided() {
+    private boolean referencesProvided() {
         return referencesPath != null;
     }
 }

--- a/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
+++ b/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
@@ -21,15 +21,15 @@ import java.util.stream.Stream;
 public class CodeReferences {
     private final ComponentsRegistry componentsRegistry;
 
-    private final Path referencesPath;
-    private final String referencesPathValue;
+    private final Path referencesFullPath;
+    private final String referencesPath;
 
     public CodeReferences(ComponentsRegistry componentsRegistry, PluginParams pluginParams) {
         this.componentsRegistry = componentsRegistry;
 
-        this.referencesPathValue = pluginParams.getOpts().get("referencesPath", null);
-        this.referencesPath = referencesPathValue != null ?
-                componentsRegistry.resourceResolver().fullPath(referencesPathValue):
+        this.referencesPath = pluginParams.getOpts().get("referencesPath", null);
+        this.referencesFullPath = referencesPath != null ?
+                componentsRegistry.resourceResolver().fullPath(referencesPath):
                 null;
     }
 
@@ -43,7 +43,7 @@ public class CodeReferences {
 
     private Map<String, Object> buildReferences() {
         MarkupTableData tableData = CsvParser.parseWithHeader(
-                componentsRegistry.resourceResolver().textContent(referencesPathValue),
+                componentsRegistry.resourceResolver().textContent(referencesPath),
                 "reference", "url");
 
         Map<String, Object> result = new LinkedHashMap<>();
@@ -56,10 +56,10 @@ public class CodeReferences {
 
     public Stream<AuxiliaryFile> auxiliaryFiles() {
         return referencesProvided() ?
-                Stream.of(AuxiliaryFile.builtTime(referencesPath)) : Stream.empty();
+                Stream.of(AuxiliaryFile.builtTime(referencesFullPath)) : Stream.empty();
     }
 
     private boolean referencesProvided() {
-        return referencesPath != null;
+        return referencesFullPath != null;
     }
 }

--- a/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
+++ b/znai-core/src/main/java/com/twosigma/znai/extensions/file/CodeReferences.java
@@ -1,0 +1,65 @@
+package com.twosigma.znai.extensions.file;
+
+import com.twosigma.znai.core.AuxiliaryFile;
+import com.twosigma.znai.core.ComponentsRegistry;
+import com.twosigma.znai.extensions.PluginParams;
+import com.twosigma.znai.parser.table.CsvParser;
+import com.twosigma.znai.parser.table.MarkupTableData;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * common code for the include-file plugin, include-java plugin, etc
+ * to handle parsing of code references, converting them to props, and handling auxiliary files.
+ *
+ * sort of like a plugin trait. Maybe a good idea to formalize traits on plugins interface level.
+ */
+public class CodeReferences {
+    private final ComponentsRegistry componentsRegistry;
+
+    private final Path referencesPath;
+    private final String referencesPathValue;
+
+    public CodeReferences(ComponentsRegistry componentsRegistry, PluginParams pluginParams) {
+        this.componentsRegistry = componentsRegistry;
+
+        this.referencesPathValue = pluginParams.getOpts().get("referencesPath", null);
+        this.referencesPath = referencesPathValue != null ?
+                componentsRegistry.resourceResolver().fullPath(referencesPathValue):
+                null;
+    }
+
+    public void updateProps(Map<String, Object> props) {
+        if (!referencesProvided()) {
+            return;
+        }
+
+        props.put("references", buildReferences());
+    }
+
+    private Map<String, Object> buildReferences() {
+        MarkupTableData tableData = CsvParser.parseWithHeader(
+                componentsRegistry.resourceResolver().textContent(referencesPathValue),
+                "reference", "url");
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        tableData.forEachRow(row -> {
+            result.put(row.get(0), Collections.singletonMap("pageUrl", row.get(1)));
+        });
+
+        return result;
+    }
+
+    public Stream<AuxiliaryFile> auxiliaryFiles() {
+        return referencesProvided() ?
+                Stream.of(AuxiliaryFile.builtTime(referencesPath)) : Stream.empty();
+    }
+
+    public boolean referencesProvided() {
+        return referencesPath != null;
+    }
+}

--- a/znai-core/src/main/java/com/twosigma/znai/extensions/file/FileIncludePlugin.java
+++ b/znai-core/src/main/java/com/twosigma/znai/extensions/file/FileIncludePlugin.java
@@ -35,6 +35,8 @@ public class FileIncludePlugin implements IncludePlugin {
     private String fileName;
     private String text;
 
+    private CodeReferences codeReferences;
+
     @Override
     public String id() {
         return "file";
@@ -50,6 +52,7 @@ public class FileIncludePlugin implements IncludePlugin {
                                 ParserHandler parserHandler,
                                 Path markupPath,
                                 PluginParams pluginParams) {
+        codeReferences = new CodeReferences(componentsRegistry, pluginParams);
         fileName = pluginParams.getFreeParam();
 
         text = FilePlugin.extractText(
@@ -61,14 +64,17 @@ public class FileIncludePlugin implements IncludePlugin {
 
         Map<String, Object> props = CodeSnippetsProps.create(langToUse, text);
         props.putAll(pluginParams.getOpts().toMap());
+        codeReferences.updateProps(props);
 
         return PluginResult.docElement(DocElementType.SNIPPET, props);
     }
 
     @Override
     public Stream<AuxiliaryFile> auxiliaryFiles(ComponentsRegistry componentsRegistry) {
-        return Stream.of(AuxiliaryFile.builtTime(
-                componentsRegistry.resourceResolver().fullPath(fileName)));
+        return Stream.concat(
+                Stream.of(AuxiliaryFile.builtTime(
+                        componentsRegistry.resourceResolver().fullPath(fileName))),
+                codeReferences.auxiliaryFiles());
     }
 
     @Override

--- a/znai-core/src/main/java/com/twosigma/znai/parser/table/CsvParser.java
+++ b/znai-core/src/main/java/com/twosigma/znai/parser/table/CsvParser.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.twosigma.znai.extensions.table;
+package com.twosigma.znai.parser.table;
 
-import com.twosigma.znai.parser.table.MarkupTableData;
-import com.twosigma.znai.parser.table.Row;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;

--- a/znai-core/src/test/groovy/com/twosigma/znai/extensions/file/CodeReferencesTest.groovy
+++ b/znai-core/src/test/groovy/com/twosigma/znai/extensions/file/CodeReferencesTest.groovy
@@ -1,0 +1,40 @@
+package com.twosigma.znai.extensions.file
+
+import com.twosigma.znai.extensions.PluginParams
+import com.twosigma.znai.parser.TestComponentsRegistry
+import org.junit.Test
+
+class CodeReferencesTest {
+    @Test
+    void "should read csv references and add to props as a map"() {
+        def codeReferences = new CodeReferences(TestComponentsRegistry.INSTANCE,
+                new PluginParams("include-file", '{referencesPath: "references/test-references.csv"}'))
+
+        def props = new LinkedHashMap()
+        codeReferences.updateProps(props)
+
+        props.should == [references: [MyClass: [pageUrl: '/reference/my-class'],
+                                      YourClass: [pageUrl: '/reference/your-class']]]
+    }
+
+    @Test
+    void "should provide auxiliary files stream"() {
+        def codeReferences = new CodeReferences(TestComponentsRegistry.INSTANCE,
+                new PluginParams("include-file", '{referencesPath: "references/test-references.csv"}'))
+
+        codeReferences.auxiliaryFiles().collect {it.path.fileName.toString()}.should == ['test-references.csv']
+    }
+
+    @Test
+    void "should not update props and should return empty auxiliary stream when no reference path was provided"() {
+        def codeReferences = new CodeReferences(TestComponentsRegistry.INSTANCE,
+                new PluginParams("include-file", ''))
+
+        codeReferences.auxiliaryFiles().collect {it}.should == []
+
+        def props = new LinkedHashMap()
+        codeReferences.updateProps(props)
+
+        props.should == [:]
+    }
+}

--- a/znai-core/src/test/groovy/com/twosigma/znai/parser/table/CsvParserTest.groovy
+++ b/znai-core/src/test/groovy/com/twosigma/znai/parser/table/CsvParserTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.twosigma.znai.extensions.table
+package com.twosigma.znai.parser.table
 
 import org.junit.Test
 

--- a/znai-core/src/test/resources/references/test-references.csv
+++ b/znai-core/src/test/resources/references/test-references.csv
@@ -1,0 +1,2 @@
+MyClass, /reference/my-class
+YourClass, /reference/your-class

--- a/znai-cpp/src/main/java/com/twosigma/znai/cpp/extensions/CppIncludePlugin.java
+++ b/znai-cpp/src/main/java/com/twosigma/znai/cpp/extensions/CppIncludePlugin.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 public class CppIncludePlugin implements IncludePlugin {
     private MarkupParser markupParser;
     private Path cppPath;
-    private CodeTokenizer codeTokenizer;
     private String fileName;
 
     @Override

--- a/znai-docs/documentation/snippets/external-code-snippets.md
+++ b/znai-docs/documentation/snippets/external-code-snippets.md
@@ -87,3 +87,15 @@ Set `spoiler` property to initially hide explanations. It may be useful when tea
 Click on the spoiler to reveal the explanations.
 
 :include-file: file-name-with-comments.js {commentsType: "inline", spoiler: true}
+
+# Code References
+
+You can turn parts of a code into links to internal or external pages. 
+
+To do that, define references in a csv file. Two columns format: `expression, link`.
+
+:include-file: references/references-demo.csv {title: "references/references-demo.csv"}
+
+    :include-file: file-name.js {referencesPath: "references/references-demo.csv"}
+    
+:include-file: file-name.js {referencesPath: "references/references-demo.csv"}

--- a/znai-docs/documentation/snippets/file-name.js
+++ b/znai-docs/documentation/snippets/file-name.js
@@ -1,5 +1,6 @@
 class JsClass {
     constructor() {
+        usefulAction()
     }
 }
 

--- a/znai-docs/documentation/snippets/json.md
+++ b/znai-docs/documentation/snippets/json.md
@@ -60,6 +60,12 @@ a line by text matching or by providing a line index.
     
 :include-json: book-store.json {highlight: ["category", 2]}
 
+# Code References
+
+You can turn parts of a json into links to internal or external pages. 
+
+
+:include-json: book-store.json {include: "$..book[0,1]", title: "Books", referencesPath: "references/json-references-demo.csv"}
 
 # Test Results
 

--- a/znai-docs/documentation/snippets/references/references-demo.csv
+++ b/znai-docs/documentation/snippets/references/references-demo.csv
@@ -1,0 +1,2 @@
+constructor, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor
+usefulAction, flow/footer

--- a/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePlugin.java
+++ b/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePlugin.java
@@ -67,6 +67,7 @@ public class JavaIncludePlugin extends JavaIncludePluginBase {
         String snippet = extractContent(javaCode);
         Map<String, Object> props = CodeSnippetsProps.create("java", snippet);
         props.putAll(pluginParams.getOpts().toMap());
+        codeReferences.updateProps(props);
 
         DocElement docElement = new DocElement(DocElementType.SNIPPET);
         props.forEach(docElement::addProp);

--- a/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePluginBase.java
+++ b/znai-java/src/main/java/com/twosigma/znai/java/extensions/JavaIncludePluginBase.java
@@ -20,6 +20,7 @@ import com.twosigma.znai.core.AuxiliaryFile;
 import com.twosigma.znai.core.ComponentsRegistry;
 import com.twosigma.znai.extensions.PluginParams;
 import com.twosigma.znai.extensions.PluginResult;
+import com.twosigma.znai.extensions.file.CodeReferences;
 import com.twosigma.znai.extensions.include.IncludePlugin;
 import com.twosigma.znai.java.parser.JavaCode;
 import com.twosigma.znai.parser.ParserHandler;
@@ -37,6 +38,7 @@ abstract public class JavaIncludePluginBase implements IncludePlugin {
     protected PluginParams pluginParams;
     protected String entry;
     protected List<String> entries;
+    protected CodeReferences codeReferences;
     private JavaIncludeResult javaIncludeResult;
 
     @Override
@@ -44,6 +46,7 @@ abstract public class JavaIncludePluginBase implements IncludePlugin {
                                 ParserHandler parserHandler,
                                 Path markupPath,
                                 PluginParams pluginParams) {
+        this.codeReferences = new CodeReferences(componentsRegistry, pluginParams);
         this.componentsRegistry = componentsRegistry;
         this.markupPath = markupPath;
         this.pluginParams = pluginParams;
@@ -65,7 +68,9 @@ abstract public class JavaIncludePluginBase implements IncludePlugin {
 
     @Override
     public Stream<AuxiliaryFile> auxiliaryFiles(ComponentsRegistry componentsRegistry) {
-        return Stream.of(AuxiliaryFile.builtTime(fullPath));
+        return Stream.concat(
+                Stream.of(AuxiliaryFile.builtTime(fullPath)),
+                codeReferences.auxiliaryFiles());
     }
 
     @Override

--- a/znai-reactjs/src/App.css
+++ b/znai-reactjs/src/App.css
@@ -106,6 +106,8 @@
     --znai-snippets-title-color: #555;
     --znai-snippets-title-background-color: #eff1f0;
     --znai-snippets-title-left-border-color: var(--znai-light-black);
+    --znai-snippets-reference-border-color: var(--znai-light-black);
+    --znai-snippets-reference-background-color: rgb(234, 237, 242);
     --znai-token-title-color: #383b3f;
     --znai-token-param-highlight-color: #660e7a;
     --znai-cli-command-color: #383b3f;

--- a/znai-reactjs/src/doc-elements/code-snippets/CodeSnippetWithInlineComments.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/CodeSnippetWithInlineComments.js
@@ -52,7 +52,7 @@ const Explanations = ({spoiler, isPresentation, slideIdx, comments}) => {
                                comments={isPresentation ? comments.slice(slideIdx, slideIdx + 1) : comments}/>
 }
 
-const CodeSnippetWithInlineComments = ({tokens, spoiler, isPresentation, meta, slideIdx}) => {
+const CodeSnippetWithInlineComments = ({tokens, spoiler, references, isPresentation, meta, slideIdx}) => {
     commentIdx = 0
     const comments = tokens.filter(t => isInlinedComment(t))
     const lines = splitTokensIntoLines(tokens)
@@ -75,6 +75,7 @@ const CodeSnippetWithInlineComments = ({tokens, spoiler, isPresentation, meta, s
                 <code>
                     {lines.map((line, idx) => <LineOfTokens key={idx} tokens={line}
                                                             isHighlighted={isHighlighted(idx)}
+                                                            references={references}
                                                             isPresentation={isPresentation}
                                                             TokenComponent={SpecialCommentToken}/>)}
                 </code>

--- a/znai-reactjs/src/doc-elements/code-snippets/LineOfTokens.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/LineOfTokens.js
@@ -16,16 +16,32 @@
 
 import React from 'react'
 
+import {enhanceMatchedTokensWithMeta} from './codeUtils'
+
 import './LineOfTokens.css'
 
-const LineOfTokens = ({tokens, isHighlighted, isPresentation, TokenComponent}) => {
+const LineOfTokens = ({tokens, references, isHighlighted, isPresentation, TokenComponent}) => {
+    console.log(tokens)
+
     const className = "code-line" + (isHighlighted ? " highlight" : "")
+    const enhancedTokens = enhanceTokens()
 
     return (
         <span className={className}>
-            {tokens.map((t, idx) => <TokenComponent key={idx} token={t} isPresentation={isPresentation}/>)}
+            {enhancedTokens.map((t, idx) => <TokenComponent key={idx} token={t} isPresentation={isPresentation}/>)}
         </span>
     )
+
+    function enhanceTokens() {
+        if (!references) {
+            return tokens
+        }
+
+        return enhanceMatchedTokensWithMeta(tokens, Object.keys(references), () => 'link', (referenceText) => {
+            const reference = references[referenceText]
+            return reference.pageUrl
+        })
+    }
 }
 
 export default LineOfTokens

--- a/znai-reactjs/src/doc-elements/code-snippets/LineOfTokens.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/LineOfTokens.js
@@ -21,8 +21,6 @@ import {enhanceMatchedTokensWithMeta} from './codeUtils'
 import './LineOfTokens.css'
 
 const LineOfTokens = ({tokens, references, isHighlighted, isPresentation, TokenComponent}) => {
-    console.log(tokens)
-
     const className = "code-line" + (isHighlighted ? " highlight" : "")
     const enhancedTokens = enhanceTokens()
 

--- a/znai-reactjs/src/doc-elements/code-snippets/SimpleCodeSnippet.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/SimpleCodeSnippet.js
@@ -56,7 +56,7 @@ class SimpleCodeSnippet extends Component {
 
     render() {
         const {displayFully} = this.state
-        const {isPresentation, slideIdx} = this.props
+        const {isPresentation, slideIdx, references} = this.props
 
         // slideIdx === 0 means no highlights, 1 - first highlight, etc
         const highlightIsVisible = !isPresentation || slideIdx > 0
@@ -68,6 +68,7 @@ class SimpleCodeSnippet extends Component {
         return (
             <pre>
                 {linesToRender.map((tokens, idx) => <LineOfTokens key={idx} tokens={tokens}
+                                                                  references={references}
                                                                   isHighlighted={highlightIsVisible && this.isHighlighted(idx, tokens)}
                                                                   isPresentation={isPresentation}
                                                                   TokenComponent={SimpleCodeToken}/>)}

--- a/znai-reactjs/src/doc-elements/code-snippets/SimpleCodeToken.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/SimpleCodeToken.js
@@ -16,14 +16,24 @@
 
 import React from 'react'
 
+import {isSimpleValueToken} from './codeUtils'
+import {documentationNavigation} from '../structure/DocumentationNavigation'
+import {isExternalUrl, onLocalUrlClick} from '../structure/links'
+
 import 'prismjs/themes/prism-coy.css'
 
 const SimpleCodeToken = ({token}) => {
-    if (isSimpleValue(token)) {
+    if (isSimpleValueToken(token)) {
         return <React.Fragment>{token}</React.Fragment>
     }
 
     const className = (token.type === 'text') ? '' : 'token ' + token.type
+    return token.link ?
+        renderLinkData(token, className):
+        renderSpan(token, className)
+}
+
+function renderSpan(token, className) {
     return (
         <span className={className} onClick={token.onClick}>
             {renderData(token)}
@@ -31,8 +41,25 @@ const SimpleCodeToken = ({token}) => {
     )
 }
 
+function renderLinkData(token, className) {
+    const isLocalNavigation = !isExternalUrl(token.link);
+
+    const url = isLocalNavigation ?
+        documentationNavigation.fullPageUrl(token.link):
+        token.link
+
+    const onClick = isLocalNavigation ? (e) => onLocalUrlClick(e, url) : null
+    const targetProp = isLocalNavigation ? {} : {target: "_blank"}
+
+    return (
+        <a href={url} className={className} onClick={onClick} {...targetProp}>
+            {renderData(token)}
+        </a>
+    )
+}
+
 function renderData(token) {
-    if (isSimpleValue(token)) {
+    if (isSimpleValueToken(token)) {
         return token
     }
 
@@ -45,10 +72,6 @@ function renderData(token) {
     }
 
     return JSON.stringify(token)
-}
-
-function isSimpleValue(token) {
-    return typeof token === 'string' || typeof token === 'number'
 }
 
 export default SimpleCodeToken

--- a/znai-reactjs/src/doc-elements/code-snippets/Snippet.demo.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/Snippet.demo.js
@@ -31,6 +31,9 @@ export function snippetsDemo(registry) {
     registry
         .add('title', () => <Snippet title="snippet title" lang="html" snippet={htmlCode()}/>)
         .add('wide with title', () => <Snippet wide={true} title="snippet title" lang="java" snippet={wideCode()}/>)
+        .add('with linked method calls', () => <Snippet wide={true} title="snippet title" lang="java"
+                                                        references={methodCallReferences()}
+                                                        snippet={codeWithMethodCalls()}/>)
         .add('with bullet points', () => <Snippet wide={false} lang="java" snippet={codeWithComments()}
                                                   commentsType="inline"/>)
         .add('with spoiler bullet points', () => <Snippet wide={false} lang="java" snippet={codeWithComments()}
@@ -108,6 +111,26 @@ function codeWithoutComments() {
         '        ...\n' +
         '    }\n' +
         '}\n'
+}
+
+function codeWithMethodCalls() {
+    return 'http.get("/end-point", http.header("h1", "v1"), ((header, body) -> {\n' +
+        '    body.get("price").should(equal(100));\n' +
+        '}));'
+}
+
+function methodCallReferences() {
+    return {
+        'http.header': {
+            pageUrl: '#http-header'
+        },
+        'body.get': {
+            pageUrl: '/chapter/page'
+        },
+        'should': {
+            pageUrl: 'http://example.com'
+        }
+    }
 }
 
 function markdownCode() {

--- a/znai-reactjs/src/doc-elements/code-snippets/codeUtils.js
+++ b/znai-reactjs/src/doc-elements/code-snippets/codeUtils.js
@@ -199,7 +199,7 @@ function findTokensThatMatchExpressions(tokens, expressions) {
                 continue
             }
 
-            running += tokenText.trim()
+            running += tokenText
 
             if (expression.indexOf(running) !== 0) {
                 running = ''

--- a/znai-reactjs/src/doc-elements/code-snippets/tokens.css
+++ b/znai-reactjs/src/doc-elements/code-snippets/tokens.css
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+.token.link {
+    cursor: pointer;
+    border-bottom: 1px solid var(--znai-snippets-reference-border-color);
+    color: var(--znai-regular-text-color);
+    background-color: var(--znai-snippets-reference-background-color);
+    text-decoration: none;
+}
+
 .token.class-name {
     color: var(--znai-class-color);
 }

--- a/znai-reactjs/src/doc-elements/structure/DocumentationNavigation.js
+++ b/znai-reactjs/src/doc-elements/structure/DocumentationNavigation.js
@@ -44,9 +44,19 @@ class DocumentationNavigation {
         this.listeners.splice(idx, 1)
     }
 
+    fullPageUrl(relativePageUrl) {
+        if (relativePageUrl.indexOf('#') === 0) {
+            return relativePageUrl
+        }
+
+        return "/" + (getDocId()  ? getDocId() : "") +
+            (relativePageUrl.indexOf('/') === 0 ? '' : '/') +
+            relativePageUrl
+    }
+
     buildUrl(id) {
-        return  "/" + (getDocId()  ? getDocId() + "/" : "") + (id.dirName + "/" + id.fileName) +
-            (id.pageSectionId ? ("#" + id.pageSectionId) : "")
+        return  this.fullPageUrl(id.dirName + "/" + id.fileName +
+            (id.pageSectionId ? ("#" + id.pageSectionId) : ""))
     }
 
     navigateToPage(id) {

--- a/znai-reactjs/src/doc-elements/structure/DocumentationNavigation.test.js
+++ b/znai-reactjs/src/doc-elements/structure/DocumentationNavigation.test.js
@@ -56,4 +56,12 @@ describe("DocumentationNavigation", () => {
         expect(location.dirName).toEqual("")
         expect(location.fileName).toEqual("index")
     })
+
+    it("builds full doc url given a relative url", () => {
+        setDocMeta({id: 'my-doc'})
+
+        expect(documentationNavigation.fullPageUrl('#anchor')).toEqual('#anchor')
+        expect(documentationNavigation.fullPageUrl('/chapter/page')).toEqual('/my-doc/chapter/page')
+        expect(documentationNavigation.fullPageUrl('chapter/page')).toEqual('/my-doc/chapter/page')
+    })
 })

--- a/znai-reactjs/src/doc-elements/structure/links.js
+++ b/znai-reactjs/src/doc-elements/structure/links.js
@@ -22,7 +22,16 @@ function isLocalUrl(url) {
         return false
     }
 
-    return url.startsWith('/' + getDocId())
+    return url.startsWith('#') ||
+        url.startsWith('/' + getDocId())
+}
+
+function isExternalUrl(url) {
+    if (!window.document) {
+        return false
+    }
+
+    return url.startsWith('http')
 }
 
 function onLocalUrlClick(e, url) {
@@ -31,4 +40,4 @@ function onLocalUrlClick(e, url) {
 }
 
 
-export {isLocalUrl, onLocalUrlClick}
+export {isLocalUrl, isExternalUrl, onLocalUrlClick}

--- a/znai-reactjs/src/theme/znai-dark/znai-dark.css
+++ b/znai-reactjs/src/theme/znai-dark/znai-dark.css
@@ -74,6 +74,8 @@
     --znai-snippets-title-color: #959595;
     --znai-snippets-title-background-color: #151a1d;
     --znai-snippets-title-left-border-color: #29343a;
+    --znai-snippets-reference-border-color: mediumpurple;
+    --znai-snippets-reference-background-color: #29264c;
     --znai-token-title-color: #dddddd;
     --znai-token-param-highlight-color: #ae59c1;
     --znai-cli-command-color: #a0aeb5;

--- a/znai/pom.xml
+++ b/znai/pom.xml
@@ -120,11 +120,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>

--- a/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
@@ -16,7 +16,7 @@
 
 package com.twosigma.znai.extensions.api;
 
-import com.twosigma.znai.extensions.table.CsvParser;
+import com.twosigma.znai.parser.table.CsvParser;
 import com.twosigma.znai.parser.MarkupParser;
 import com.twosigma.znai.parser.MarkupParserResult;
 import com.twosigma.znai.parser.table.MarkupTableData;

--- a/znai/src/main/java/com/twosigma/znai/extensions/charts/ChartIncludePlugin.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/charts/ChartIncludePlugin.java
@@ -21,7 +21,7 @@ import com.twosigma.znai.core.ComponentsRegistry;
 import com.twosigma.znai.extensions.PluginParams;
 import com.twosigma.znai.extensions.PluginResult;
 import com.twosigma.znai.extensions.include.IncludePlugin;
-import com.twosigma.znai.extensions.table.CsvParser;
+import com.twosigma.znai.parser.table.CsvParser;
 import com.twosigma.znai.parser.ParserHandler;
 
 import java.nio.file.Path;

--- a/znai/src/main/java/com/twosigma/znai/extensions/table/TableIncludePlugin.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/table/TableIncludePlugin.java
@@ -25,6 +25,7 @@ import com.twosigma.znai.parser.MarkupParser;
 import com.twosigma.znai.parser.MarkupParserResult;
 import com.twosigma.znai.parser.ParserHandler;
 import com.twosigma.znai.parser.docelement.DocElementType;
+import com.twosigma.znai.parser.table.CsvParser;
 import com.twosigma.znai.parser.table.MarkupTableData;
 import com.twosigma.znai.search.SearchScore;
 import com.twosigma.znai.search.SearchText;


### PR DESCRIPTION
related to https://github.com/twosigma/znai/issues/314

Adds support for simple code links via two columns csv file:

![image](https://user-images.githubusercontent.com/11657860/69774105-f306d580-1162-11ea-8d24-f9b1de1326bc.png)
