### PR TITLE
re-enable scroll to top and section highlights after presentation mode

### DIFF
--- a/znai-reactjs/src/doc-elements/Documentation.js
+++ b/znai-reactjs/src/doc-elements/Documentation.js
@@ -254,7 +254,7 @@ export class Documentation extends Component {
         } else if (mode === DocumentationModes.DEFAULT && e.code === 'ArrowRight' && e.ctrlKey) {
             this.onNextPage()
         } else if (e.code === "Escape") {
-            this.setState({mode: DocumentationModes.DEFAULT})
+            this.onPresentationClose()
         }
     }
 
@@ -287,10 +287,14 @@ export class Documentation extends Component {
     mouseClickHandler() {
     }
 
+    saveMainPanelDomRef() {
+        this.mainPanelDom = document.querySelector(".main-panel")
+    }
+
     enableScrollListener() {
         // server side rendering guard
         if (window.addEventListener) {
-            this.mainPanelDom = document.querySelector(".main-panel")
+            this.saveMainPanelDomRef()
             this.mainPanelDom.addEventListener("scroll", this.updateCurrentPageSection)
         }
     }
@@ -395,7 +399,16 @@ export class Documentation extends Component {
     }
 
     onPresentationClose() {
-        this.setState({mode: DocumentationModes.DEFAULT})
+        this.switchToDefaultMode()
+    }
+
+    switchToDefaultMode() {
+        this.setState({mode: DocumentationModes.DEFAULT}, () => {
+            this.saveMainPanelDomRef()
+            this.extractPageSectionNodes()
+            this.updateCurrentPageSection()
+            this.enableScrollListener()
+        })
     }
 
     onTocItemClick(dirName, fileName) {


### PR DESCRIPTION
Right now if you exit presentation mode and try to navigate to any page, scroll position will not jump to 0. 
Also scrolling within the page won't highlight section names in TOC.

Fix is not very React way and I think Default documentation Mode needs to be extracted in its own component so all the enabling/disabling logic will be handled using lifecycle methods. 

Plan is to add UI tests first and then we can start bigger refactoring. 