### PR TITLE
maintain only svg width when auto fit

### DIFF
--- a/znai-reactjs/src/doc-elements/svg/Svg.js
+++ b/znai-reactjs/src/doc-elements/svg/Svg.js
@@ -79,7 +79,7 @@ class Svg extends Component {
 
         const bbox = this.svgNode.getBBox();
         this.svgNode.setAttribute("width", (bbox.width * scale) + "px")
-        this.svgNode.setAttribute("height", (bbox.height * scale) + "px")
+        this.svgNode.removeAttribute("height")
         this.svgNode.setAttribute("viewBox", `${bbox.x} ${bbox.y} ${bbox.width} ${bbox.height}`)
     }
 


### PR DESCRIPTION
First step on making SVGs more mobile friendly. 

This is so SVG width could be forced with outside CSS like `max-width: 100%` without creating extra gap due to already set height. 